### PR TITLE
Add support for array paths (Fix #1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 'use strict';
 
 module.exports = exports = function (obj, path, defaultValue, delimiter) {
-	var arr;
-	var i;
-	if (typeof path === 'string') {
-		arr = path.split(delimiter || '.');
-		for (i = 0; i < arr.length; i++) {
-			if (obj && (obj.hasOwnProperty(arr[i]) || obj[arr[i]])) {
-				obj = obj[arr[i]];
+	if (typeof path === 'string') path = path.split(delimiter || '.');
+	if (Array.isArray(path)) {
+		var len = path.length;
+		for (var i = 0; i < len; i++) {
+			if (obj && (obj.hasOwnProperty(path[i]) || obj[path[i]])) {
+				obj = obj[path[i]];
 			} else {
 				return defaultValue;
 			}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "get values from javascript objects by specifying a path",
   "main": "index.js",
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test",
+    "prepublish": "gulp test && gulp lint"
   },
   "author": "skratchdot",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -40,6 +40,7 @@ describe('object-get-path', function () {
 		expect(getPath(obj, 'invalidKey', 'wow')).to.equal('wow');
 		expect(getPath(obj, 'invalidKey', null)).to.equal(null);
 		expect(getPath(obj, 'nested.invalidKey', 'nested')).to.equal('nested');
+		expect(getPath(obj, '', 'DEFAULT')).to.equal('DEFAULT');
 	});
 	it('should handle alternative delimiters', function () {
 		expect(getPath(obj, 'nested.is.cool', null, '.')).to.equal(true);
@@ -60,10 +61,15 @@ describe('object-get-path', function () {
 		expect(getPath(obj, 'nested.thing.foo')).to.equal('bar');
 		expect(getPath(obj, 'nested.is.cool')).to.equal(true);
 	});
+	it('should accept arrays as path', function () {
+		// special use case
+		expect(getPath(obj, [], 'DEFAULT')).to.equal(obj);
+		expect(getPath(obj, ['dataDate'])).to.equal(now);
+		expect(getPath(obj, ['nested', 'is', 'cool'])).to.equal(true);
+	});
 	it('should return the default value when key is not a string', function () {
 		var defaultValue = Math.random();
 		expect(getPath(obj, {}, defaultValue)).to.equal(defaultValue);
-		expect(getPath(obj, [], defaultValue)).to.equal(defaultValue);
 		expect(getPath(obj, null, defaultValue)).to.equal(defaultValue);
 		expect(getPath(obj, 11, defaultValue)).to.equal(defaultValue);
 		expect(getPath(obj, undefined, defaultValue)).to.equal(defaultValue);


### PR DESCRIPTION
_Warning_: uses `Array.isArray` (that it's not supported on obsolete platforms but fully supported on non-obsolete ones: http://kangax.github.io/compat-table/es5/). I prefer to use it, but maybe you want to support older platforms.

This commit adds a package.json script `prepublish` that run tests and checks eslint compatibility. It is run automatically before `publish` and can be invoked using: `npm run prepublish``
